### PR TITLE
feat: Helm add existing secret

### DIFF
--- a/install/helm/vault-sync/Chart.yaml
+++ b/install/helm/vault-sync/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/install/helm/vault-sync/templates/deployment.yaml
+++ b/install/helm/vault-sync/templates/deployment.yaml
@@ -57,8 +57,8 @@ spec:
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ $key }}
-                  key: {{ $secretName }}
+                  name: {{ $secretName }}
+                  key: {{ $key }}
             {{- end }}
           {{- end }}
           {{- if .Values.existingSecretName }}

--- a/install/helm/vault-sync/templates/deployment.yaml
+++ b/install/helm/vault-sync/templates/deployment.yaml
@@ -51,19 +51,20 @@ spec:
           env:
             - name: RUST_LOG
               value: info'
-          {{- if not .Values.secrets.existingSecretName }}
-            {{- range $key, $_ := .Values.secrets.values }}
+          {{- if not .Values.existingSecretName }}
+            {{- $secretName := include "vault-sync.fullname" . }}
+            {{- range $key, $_ := .Values.secrets }}
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
-                  name: vault-sync
-                  key: {{ $key }}
+                  name: {{ $key }}
+                  key: {{ $secretName }}
             {{- end }}
           {{- end }}
-          {{- if .Values.secrets.existingSecretName }}
+          {{- if .Values.existingSecretName }}
           envFrom:
             - secretRef:
-                name: {{ .Values.secrets.existingSecretName }}
+                name: {{ .Values.existingSecretName }}
           {{- end }}
           {{- with .Values.environmentVars }}
           {{- toYaml . | nindent 12 }}

--- a/install/helm/vault-sync/templates/deployment.yaml
+++ b/install/helm/vault-sync/templates/deployment.yaml
@@ -50,14 +50,20 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: RUST_LOG
-              value: info
-          {{- $secretName := include "vault-sync.fullname" . }}
-          {{- range $key, $value := .Values.secrets }}
+              value: info'
+          {{- if not .Values.secrets.existingSecretName }}
+            {{- range $key, $_ := .Values.secrets.values }}
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
+                  name: vault-sync
                   key: {{ $key }}
-                  name: {{ $secretName }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.secrets.existingSecretName }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secrets.existingSecretName }}
           {{- end }}
           {{- with .Values.environmentVars }}
           {{- toYaml . | nindent 12 }}

--- a/install/helm/vault-sync/templates/secret.yaml
+++ b/install/helm/vault-sync/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secrets.existingSecretName }}
+{{- if not .Values.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +7,7 @@ metadata:
     {{- include "vault-sync.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- range $key, $entry := .Values.secrets.values }}
+{{- range $key, $entry := .Values.secrets }}
   {{ $key }}: {{ $entry | quote }}
   {{- end }}
 {{- end }}

--- a/install/helm/vault-sync/templates/secret.yaml
+++ b/install/helm/vault-sync/templates/secret.yaml
@@ -7,7 +7,5 @@ metadata:
     {{- include "vault-sync.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- range $key, $entry := .Values.secrets }}
-  {{ $key }}: {{ $entry | quote }}
-  {{- end }}
+  {{- toYaml .Values.secrets | nindent 2 }}
 {{- end }}

--- a/install/helm/vault-sync/templates/secret.yaml
+++ b/install/helm/vault-sync/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "vault-sync.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- range $key, $entry := .Values.secrets.values }}
+{{- range $key, $entry := .Values.secrets.values }}
   {{ $key }}: {{ $entry | quote }}
   {{- end }}
 {{- end }}

--- a/install/helm/vault-sync/templates/secret.yaml
+++ b/install/helm/vault-sync/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.secrets.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,4 +7,7 @@ metadata:
     {{- include "vault-sync.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- toYaml .Values.secrets | nindent 2 }}
+  {{- range $key, $entry := .Values.secrets.values }}
+  {{ $key }}: {{ $entry | quote }}
+  {{- end }}
+{{- end }}

--- a/install/helm/vault-sync/values.yaml
+++ b/install/helm/vault-sync/values.yaml
@@ -20,16 +20,15 @@ vaultSync:
 #    token_ttl: 86400
 #    token_max_ttl: 2764800
 
+existingSecretName: ""
 # Secrets must be base64 encoded
 secrets:
-  existingSecretName: ""
-  values:
-    VAULT_SYNC_SRC_TOKEN: eHh4
-  #  VAULT_SYNC_SRC_ROLE_ID: xxx
-  #  VAULT_SYNC_SRC_SECRET_ID: xxx
-    VAULT_SYNC_DST_TOKEN: eHh4
-  #  VAULT_SYNC_DST_ROLE_ID: xxx
-  #  VAULT_SYNC_DST_SECRET_ID: xxx
+  VAULT_SYNC_SRC_TOKEN: eHh4
+#  VAULT_SYNC_SRC_ROLE_ID: xxx
+#  VAULT_SYNC_SRC_SECRET_ID: xxx
+  VAULT_SYNC_DST_TOKEN: eHh4
+#  VAULT_SYNC_DST_ROLE_ID: xxx
+#  VAULT_SYNC_DST_SECRET_ID: xxx
 
 replicaCount: 1
 

--- a/install/helm/vault-sync/values.yaml
+++ b/install/helm/vault-sync/values.yaml
@@ -37,7 +37,7 @@ image:
   repository: pbchekin/vault-sync
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.11.0"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/install/helm/vault-sync/values.yaml
+++ b/install/helm/vault-sync/values.yaml
@@ -22,12 +22,14 @@ vaultSync:
 
 # Secrets must be base64 encoded
 secrets:
-  VAULT_SYNC_SRC_TOKEN: eHh4
-#  VAULT_SYNC_SRC_ROLE_ID: xxx
-#  VAULT_SYNC_SRC_SECRET_ID: xxx
-  VAULT_SYNC_DST_TOKEN: eHh4
-#  VAULT_SYNC_DST_ROLE_ID: xxx
-#  VAULT_SYNC_DST_SECRET_ID: xxx
+  existingSecretName: ""
+  values:
+    VAULT_SYNC_SRC_TOKEN: eHh4
+  #  VAULT_SYNC_SRC_ROLE_ID: xxx
+  #  VAULT_SYNC_SRC_SECRET_ID: xxx
+    VAULT_SYNC_DST_TOKEN: eHh4
+  #  VAULT_SYNC_DST_ROLE_ID: xxx
+  #  VAULT_SYNC_DST_SECRET_ID: xxx
 
 replicaCount: 1
 

--- a/install/helm/vault-sync/values.yaml
+++ b/install/helm/vault-sync/values.yaml
@@ -37,7 +37,7 @@ image:
   repository: pbchekin/vault-sync
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.9.2"
+  tag: "0.11.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
@pbchekin 

This MR will enable the ability for the Helm chart to use an existing secret as mentioned in #29 

Changes Made:
* Added existingSecret functionality
* Bumped Chart version
* Removed image tag from `values.yaml` so it defaults to the app version.

Additional Notes:
* I set `existingSecretName` at the root of `values.yaml` so that `secrets` can maintain it's current design and not have this ending up as a breaking change. 